### PR TITLE
Removing part of my last request

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,8 +178,6 @@ Parser.prototype.parse = function parse(bytes) {
       break;
     }
 
-    if (i !== 0) bytesRemaining--;
-
     // @TODO Order this in order of importance
     // @TODO see if we can reduce the amount i += calls by setting rn value..
     if (charCode === 67) {


### PR DESCRIPTION
For some reason, when I first made my changes to fix bytesRemaining I needed line 181 to have bytesRemaining-- unless it'd fall behind. However, this might have been due to a bad version of node, or something else as now when running it that line must be taken out in order to maintain an accurate bytesRemaining count. Sorry about the confusion.
